### PR TITLE
Functional replacement for genesis state access

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,15 @@ Due to the large file sizes genesis states are not directly included in the `ind
 but have to be accessed directly, e.g.:
 
 ```javascript
-const mainnetGenesisState = require('ethereumjs-common/genesisStates/mainnet')
+const mainnetGenesisState = require('ethereumjs-common/dist/genesisStates/mainnet')
 ```
 
-Or by choosing dynamically:
+Or by accessing dynamically:
 
 ```javascript
-const genesisStates = require('ethereumjs-common/genesisStates')
-const mainnetGenesisState = genesisStates['mainnet']
-const mainnetGenesisState = genesisStates[genesisStates['names'][1]] // alternative via chain Id
+const genesisStates = require('ethereumjs-common/dist/genesisStates')
+const mainnetGenesisState = genesisStates.genesisStateByName('mainnet')
+const mainnetGenesisState = genesisStates.genesisStateById(1) // alternative via network Id
 ```
 
 # LICENSE

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,4 +12,179 @@
 - [genesisStatesType](interfaces/genesisstatestype.md)
 - [hardforkOptions](interfaces/hardforkoptions.md)
 
+### Functions
+
+- [genesisStateById](#genesisstatebyid)
+- [genesisStateByName](#genesisstatebyname)
+
+### Object literals
+
+- [genesisStates](#genesisstates)
+
+---
+
+## Functions
+
+<a id="genesisstatebyid"></a>
+
+### genesisStateById
+
+▸ **genesisStateById**(id: _`number`_): `any`
+
+_Defined in [genesisStates/index.ts:23](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L23)_
+
+Returns the genesis state by network ID
+
+**Parameters:**
+
+| Name | Type     | Description                |
+| ---- | -------- | -------------------------- |
+| id   | `number` | ID of the network (e.g. 1) |
+
+**Returns:** `any`
+Dictionary with genesis accounts
+
+---
+
+<a id="genesisstatebyname"></a>
+
+### genesisStateByName
+
+▸ **genesisStateByName**(name: _`string`_): `any`
+
+_Defined in [genesisStates/index.ts:32](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L32)_
+
+Returns the genesis state by network name
+
+**Parameters:**
+
+| Name | Type     | Description                          |
+| ---- | -------- | ------------------------------------ |
+| name | `string` | Name of the network (e.g. 'mainnet') |
+
+**Returns:** `any`
+Dictionary with genesis accounts
+
+---
+
+## Object literals
+
+<a id="genesisstates"></a>
+
+### `<Const>` genesisStates
+
+**genesisStates**: _`object`_
+
+_Defined in [genesisStates/index.ts:3](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L3)_
+
+<a id="genesisstates.goerli"></a>
+
+#### goerli
+
+**● goerli**: _`any`_ = require('./goerli.json')
+
+_Defined in [genesisStates/index.ts:15](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L15)_
+
+---
+
+<a id="genesisstates.kovan"></a>
+
+#### kovan
+
+**● kovan**: _`any`_ = require('./kovan.json')
+
+_Defined in [genesisStates/index.ts:14](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L14)_
+
+---
+
+<a id="genesisstates.mainnet"></a>
+
+#### mainnet
+
+**● mainnet**: _`any`_ = require('./mainnet.json')
+
+_Defined in [genesisStates/index.ts:11](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L11)_
+
+---
+
+<a id="genesisstates.rinkeby"></a>
+
+#### rinkeby
+
+**● rinkeby**: _`any`_ = require('./rinkeby.json')
+
+_Defined in [genesisStates/index.ts:13](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L13)_
+
+---
+
+<a id="genesisstates.ropsten"></a>
+
+#### ropsten
+
+**● ropsten**: _`any`_ = require('./ropsten.json')
+
+_Defined in [genesisStates/index.ts:12](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L12)_
+
+---
+
+<a id="genesisstates.names"></a>
+
+#### names
+
+**names**: _`object`_
+
+_Defined in [genesisStates/index.ts:4](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L4)_
+
+<a id="genesisstates.names.1"></a>
+
+#### 1
+
+**● 1**: _`string`_ = "mainnet"
+
+_Defined in [genesisStates/index.ts:5](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L5)_
+
+---
+
+<a id="genesisstates.names.3"></a>
+
+#### 3
+
+**● 3**: _`string`_ = "ropsten"
+
+_Defined in [genesisStates/index.ts:6](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L6)_
+
+---
+
+<a id="genesisstates.names.4"></a>
+
+#### 4
+
+**● 4**: _`string`_ = "rinkeby"
+
+_Defined in [genesisStates/index.ts:7](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L7)_
+
+---
+
+<a id="genesisstates.names.42"></a>
+
+#### 42
+
+**● 42**: _`string`_ = "kovan"
+
+_Defined in [genesisStates/index.ts:8](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L8)_
+
+---
+
+<a id="genesisstates.names.6284"></a>
+
+#### 6284
+
+**● 6284**: _`string`_ = "goerli"
+
+_Defined in [genesisStates/index.ts:9](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/genesisStates/index.ts#L9)_
+
+---
+
+---
+
 ---

--- a/docs/classes/common.md
+++ b/docs/classes/common.md
@@ -52,7 +52,7 @@ Common class to access chain and hardfork parameters
 
 ⊕ **new Common**(chain: _`string` | `number` | `object`_, hardfork?: _`string` | `null`_, supportedHardforks?: _`Array`<`string`>_): [Common](common.md)
 
-_Defined in [index.ts:17](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L17)_
+_Defined in [index.ts:17](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L17)_
 
 _**constructor**_:
 
@@ -76,7 +76,7 @@ _**constructor**_:
 
 ▸ **\_chooseHardfork**(hardfork?: _`string` | `null`_, onlySupported?: _`undefined` | `false` | `true`_): `string`
 
-_Defined in [index.ts:96](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L96)_
+_Defined in [index.ts:96](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L96)_
 
 Internal helper function to choose between hardfork set and hardfork provided as param
 
@@ -98,7 +98,7 @@ Hardfork chosen to be used
 
 ▸ **\_getHardfork**(hardfork: _`string`_): `any`
 
-_Defined in [index.ts:115](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L115)_
+_Defined in [index.ts:115](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L115)_
 
 Internal helper function, returns the params for the given hardfork for the chain set
 
@@ -119,7 +119,7 @@ Dictionary with hardfork params
 
 ▸ **\_isSupportedHardfork**(hardfork: _`string` | `null`_): `boolean`
 
-_Defined in [index.ts:128](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L128)_
+_Defined in [index.ts:128](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L128)_
 
 Internal helper function to check if a hardfork is set to be supported by the library
 
@@ -140,7 +140,7 @@ True if hardfork is supported
 
 ▸ **activeHardfork**(blockNumber?: _`number` | `null`_, opts?: _[hardforkOptions](../interfaces/hardforkoptions.md)_): `string`
 
-_Defined in [index.ts:292](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L292)_
+_Defined in [index.ts:292](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L292)_
 
 Returns the latest active hardfork name for chain or block or throws if unavailable
 
@@ -162,7 +162,7 @@ Hardfork name
 
 ▸ **activeHardforks**(blockNumber?: _`number` | `null`_, opts?: _[hardforkOptions](../interfaces/hardforkoptions.md)_): `Array`<`any`>
 
-_Defined in [index.ts:272](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L272)_
+_Defined in [index.ts:272](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L272)_
 
 Returns the active hardfork switches for the current chain
 
@@ -184,7 +184,7 @@ Array with hardfork arrays
 
 ▸ **activeOnBlock**(blockNumber: _`number`_, opts?: _[hardforkOptions](../interfaces/hardforkoptions.md)_): `boolean`
 
-_Defined in [index.ts:202](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L202)_
+_Defined in [index.ts:202](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L202)_
 
 Alias to hardforkIsActiveOnBlock when hardfork is set
 
@@ -206,7 +206,7 @@ True if HF is active on block number
 
 ▸ **bootstrapNodes**(): `any`
 
-_Defined in [index.ts:367](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L367)_
+_Defined in [index.ts:367](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L367)_
 
 Returns bootstrap nodes for the current chain
 
@@ -221,7 +221,7 @@ Dict with bootstrap nodes
 
 ▸ **chainId**(): `number`
 
-_Defined in [index.ts:383](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L383)_
+_Defined in [index.ts:383](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L383)_
 
 Returns the Id of current chain
 
@@ -236,7 +236,7 @@ chain Id
 
 ▸ **chainName**(): `string`
 
-_Defined in [index.ts:391](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L391)_
+_Defined in [index.ts:391](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L391)_
 
 Returns the name of current chain
 
@@ -251,7 +251,7 @@ chain name (lower case)
 
 ▸ **consensus**(hardfork?: _`undefined` | `string`_): `string`
 
-_Defined in [index.ts:332](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L332)_
+_Defined in [index.ts:332](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L332)_
 
 Provide the consensus type for the hardfork set or provided as param
 
@@ -272,7 +272,7 @@ Consensus type (e.g. 'pow', 'poa')
 
 ▸ **finality**(hardfork?: _`undefined` | `string`_): `string`
 
-_Defined in [index.ts:342](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L342)_
+_Defined in [index.ts:342](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L342)_
 
 Provide the finality type for the hardfork set or provided as param
 
@@ -293,7 +293,7 @@ Finality type (e.g. 'pos', null of no finality)
 
 ▸ **genesis**(): `any`
 
-_Defined in [index.ts:351](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L351)_
+_Defined in [index.ts:351](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L351)_
 
 Returns the Genesis parameters of current chain
 
@@ -308,7 +308,7 @@ Genesis dictionary
 
 ▸ **gteHardfork**(hardfork: _`string`_, opts?: _[hardforkOptions](../interfaces/hardforkoptions.md)_): `boolean`
 
-_Defined in [index.ts:246](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L246)_
+_Defined in [index.ts:246](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L246)_
 
 Alias to hardforkGteHardfork when hardfork is set
 
@@ -330,7 +330,7 @@ True if hardfork set is greater than hardfork provided
 
 ▸ **hardfork**(): `string` | `null`
 
-_Defined in [index.ts:375](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L375)_
+_Defined in [index.ts:375](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L375)_
 
 Returns the hardfork set
 
@@ -345,7 +345,7 @@ Hardfork name
 
 ▸ **hardforkBlock**(hardfork?: _`undefined` | `string`_): `number`
 
-_Defined in [index.ts:307](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L307)_
+_Defined in [index.ts:307](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L307)_
 
 Returns the hardfork change block for hardfork provided or set
 
@@ -366,7 +366,7 @@ Block number
 
 ▸ **hardforkGteHardfork**(hardfork1: _`string` | `null`_, hardfork2: _`string`_, opts?: _[hardforkOptions](../interfaces/hardforkoptions.md)_): `boolean`
 
-_Defined in [index.ts:213](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L213)_
+_Defined in [index.ts:213](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L213)_
 
 Sequence based check if given or set HF1 is greater than or equal HF2
 
@@ -389,7 +389,7 @@ True if HF1 gte HF2
 
 ▸ **hardforkIsActiveOnBlock**(hardfork: _`string` | `null`_, blockNumber: _`number`_, opts?: _[hardforkOptions](../interfaces/hardforkoptions.md)_): `boolean`
 
-_Defined in [index.ts:183](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L183)_
+_Defined in [index.ts:183](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L183)_
 
 Checks if set or provided hardfork is active on block number
 
@@ -412,7 +412,7 @@ True if HF is active on block number
 
 ▸ **hardforkIsActiveOnChain**(hardfork?: _`string` | `null`_, opts?: _[hardforkOptions](../interfaces/hardforkoptions.md)_): `boolean`
 
-_Defined in [index.ts:256](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L256)_
+_Defined in [index.ts:256](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L256)_
 
 Checks if given or set hardfork is active on the chain
 
@@ -434,7 +434,7 @@ True if hardfork is active on the chain
 
 ▸ **hardforks**(): `any`
 
-_Defined in [index.ts:359](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L359)_
+_Defined in [index.ts:359](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L359)_
 
 Returns the hardforks for current chain
 
@@ -449,7 +449,7 @@ Array with arrays of hardforks
 
 ▸ **isHardforkBlock**(blockNumber: _`number`_, hardfork?: _`undefined` | `string`_): `boolean`
 
-_Defined in [index.ts:318](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L318)_
+_Defined in [index.ts:318](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L318)_
 
 True if block number provided is the hardfork (given or set) change block of the current chain
 
@@ -471,7 +471,7 @@ True if blockNumber is HF block
 
 ▸ **networkId**(): `number`
 
-_Defined in [index.ts:399](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L399)_
+_Defined in [index.ts:399](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L399)_
 
 Returns the Id of current network
 
@@ -486,7 +486,7 @@ network Id
 
 ▸ **param**(topic: _`string`_, name: _`string`_, hardfork?: _`undefined` | `string`_): `any`
 
-_Defined in [index.ts:145](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L145)_
+_Defined in [index.ts:145](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L145)_
 
 Returns the parameter corresponding to a hardfork
 
@@ -508,7 +508,7 @@ Returns the parameter corresponding to a hardfork
 
 ▸ **paramByBlock**(topic: _`string`_, name: _`string`_, blockNumber: _`number`_): `any`
 
-_Defined in [index.ts:170](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L170)_
+_Defined in [index.ts:170](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L170)_
 
 Returns a parameter for the hardfork active on block number
 
@@ -530,7 +530,7 @@ Returns a parameter for the hardfork active on block number
 
 ▸ **setChain**(chain: _`string` | `number` | `object`_): `any`
 
-_Defined in [index.ts:44](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L44)_
+_Defined in [index.ts:44](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L44)_
 
 Sets the chain
 
@@ -551,7 +551,7 @@ The dictionary with parameters set as chain
 
 ▸ **setHardfork**(hardfork: _`string` | `null`_): `void`
 
-_Defined in [index.ts:75](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L75)_
+_Defined in [index.ts:75](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L75)_
 
 Sets the hardfork to get params for
 

--- a/docs/interfaces/chainstype.md
+++ b/docs/interfaces/chainstype.md
@@ -26,7 +26,7 @@
 
 **● names**: _`object`_
 
-_Defined in [types.ts:9](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/types.ts#L9)_
+_Defined in [types.ts:9](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/types.ts#L9)_
 
 #### Type declaration
 

--- a/docs/interfaces/genesisstatestype.md
+++ b/docs/interfaces/genesisstatestype.md
@@ -26,7 +26,7 @@
 
 **● names**: _`object`_
 
-_Defined in [types.ts:2](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/types.ts#L2)_
+_Defined in [types.ts:2](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/types.ts#L2)_
 
 #### Type declaration
 

--- a/docs/interfaces/hardforkoptions.md
+++ b/docs/interfaces/hardforkoptions.md
@@ -23,7 +23,7 @@
 
 **● onlyActive**: _`undefined` | `false` | `true`_
 
-_Defined in [index.ts:8](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L8)_
+_Defined in [index.ts:8](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L8)_
 
 optional, only active HFs (default: false)
 
@@ -35,7 +35,7 @@ optional, only active HFs (default: false)
 
 **● onlySupported**: _`undefined` | `false` | `true`_
 
-_Defined in [index.ts:6](https://github.com/ethereumjs/ethereumjs-common/blob/12f6f69/src/index.ts#L6)_
+_Defined in [index.ts:6](https://github.com/ethereumjs/ethereumjs-common/blob/c779647/src/index.ts#L6)_
 
 optional, only allow supported HFs (default: false)
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Resources common to all Ethereum implementations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p ./tsconfig.prod.json",
     "prepublishOnly": "npm run test && npm run build",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "unitTests": "ts-node ./node_modules/tape/bin/tape ./tests/*.ts",
     "test": "npm run lint && npm run unitTests",
     "test:fix": "npm run lint:fix && npm run unitTests",
-    "docs:build": "typedoc --out docs --excludePrivate --excludeExternals --mode file --readme none --theme markdown --mdEngine github src/*.ts"
+    "docs:build": "typedoc --out docs --excludePrivate --excludeExternals --mode file --readme none --theme markdown --mdEngine github src/*.ts src/genesisStates/*.ts"
   },
   "repository": {
     "type": "git",

--- a/src/genesisStates/index.ts
+++ b/src/genesisStates/index.ts
@@ -1,6 +1,6 @@
 import { genesisStatesType } from './../types'
 
-export const genesisStates: genesisStatesType = {
+const genesisStates: genesisStatesType = {
   names: {
     '1': 'mainnet',
     '3': 'ropsten',
@@ -13,4 +13,22 @@ export const genesisStates: genesisStatesType = {
   rinkeby: require('./rinkeby.json'),
   kovan: require('./kovan.json'),
   goerli: require('./goerli.json'),
+}
+
+/**
+ * Returns the genesis state by network ID
+ * @param id ID of the network (e.g. 1)
+ * @returns Dictionary with genesis accounts
+ */
+export function genesisStateById(id: number): any {
+  return genesisStates[genesisStates['names'][id]]
+}
+
+/**
+ * Returns the genesis state by network name
+ * @param name Name of the network (e.g. 'mainnet')
+ * @returns Dictionary with genesis accounts
+ */
+export function genesisStateByName(name: string): any {
+  return genesisStates[name]
 }

--- a/tests/genesisStates.ts
+++ b/tests/genesisStates.ts
@@ -1,0 +1,22 @@
+import * as tape from 'tape'
+import { genesisStateById, genesisStateByName } from '../src/genesisStates/'
+
+tape('[genesisStates]: Genesis state access', function(t: tape.Test) {
+  t.test('Should be able to access by ID and name', function(st: tape.Test) {
+    let genesisState = genesisStateById(6284)
+    st.equal(
+      genesisState['0x0000000000000000000000000000000000000008'],
+      '0x1',
+      'Access by id (goerli)',
+    )
+
+    genesisState = genesisStateByName('goerli')
+    st.equal(
+      genesisState['0x0000000000000000000000000000000000000008'],
+      '0x1',
+      'Access by name (goerli)',
+    )
+
+    st.end()
+  })
+})


### PR DESCRIPTION
I did some manual testing of the TypeScript-updated library by injecting a packed library into the VM `node_modules` folder and realized that the current static [genesis state access method](https://github.com/ethereumjs/ethereumjs-common#genesis-states) is broken along with the distribution reorg.

After tinkering around a bit I came to the conclusion that this cannot be properly recreated with the switch to `ES6` import syntax and we have to do a breaking change here and then release the updated library as `v1.0.0` (which should be ok).

This PR introduces two new methods `genesisStateById`, `genesisStateByName` which can be directly imported and used for access the genesis state dictionaries. It also updates `README` and docs and adds two new test cases.