### PR TITLE
Add petersburg aka constantinople fix support

### DIFF
--- a/src/chains/mainnet.json
+++ b/src/chains/mainnet.json
@@ -52,7 +52,13 @@
     },
     {
       "name": "constantinople",
-      "block": null,
+      "block": 7280000,
+      "consensus": "pow",
+      "finality": null
+    },
+    {
+      "name": "petersburg",
+      "block": 7280000,
       "consensus": "pow",
       "finality": null
     }

--- a/src/chains/ropsten.json
+++ b/src/chains/ropsten.json
@@ -52,7 +52,13 @@
     },
     {
       "name": "constantinople",
-      "block": null,
+      "block": 4230000,
+      "consensus": "pow",
+      "finality": null
+    },
+    {
+      "name": "petersburg",
+      "block": 4939394,
       "consensus": "pow",
       "finality": null
     }

--- a/src/hardforks/constantinople.json
+++ b/src/hardforks/constantinople.json
@@ -1,9 +1,9 @@
 {
   "name": "constantinople",
-  "comment": "Hardfork with new instructions and protocol changes",
+  "comment": "Postponed hardfork including EIP-1283 (SSTORE gas metering changes)",
   "eip": {
     "url": "https://eips.ethereum.org/EIPS/eip-1013",
-    "status": "Draft"
+    "status": "Final"
   },
   "gasConfig": {},
   "gasPrices": {

--- a/src/hardforks/index.ts
+++ b/src/hardforks/index.ts
@@ -6,4 +6,5 @@ export const hardforks = [
   ['spuriousDragon', require('./spuriousDragon.json')],
   ['byzantium', require('./byzantium.json')],
   ['constantinople', require('./constantinople.json')],
+  ['petersburg', require('./petersburg.json')],
 ]

--- a/src/hardforks/petersburg.json
+++ b/src/hardforks/petersburg.json
@@ -1,0 +1,43 @@
+{
+  "name": "petersburg",
+  "comment": "Aka constantinopleFix, removes EIP-1283, activate together with or after constantinople",
+  "eip": {
+    "url": "https://github.com/ethereum/EIPs/pull/1716",
+    "status": "Draft"
+  },
+  "gasConfig": {},
+  "gasPrices": {
+    "netSstoreNoopGas": {
+      "v": null,
+      "d": "Removed along EIP-1283"
+    },
+    "netSstoreInitGas": {
+      "v": null,
+      "d": "Removed along EIP-1283"
+    },
+    "netSstoreCleanGas": {
+      "v": null,
+      "d": "Removed along EIP-1283"
+    },
+    "netSstoreDirtyGas": {
+      "v": null,
+      "d": "Removed along EIP-1283"
+    },
+    "netSstoreClearRefund": {
+      "v": null,
+      "d": "Removed along EIP-1283"
+    },
+    "netSstoreResetRefund": {
+      "v": null,
+      "d": "Removed along EIP-1283"
+    },
+    "netSstoreResetClearRefund": {
+      "v": null,
+      "d": "Removed along EIP-1283"
+    }
+  },
+  "vm": {},
+  "pow": {},
+  "casper": {},
+  "sharding": {}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,8 +226,8 @@ export default class Common {
       hardforks = this.hardforks()
     }
 
-    let posHf1 = 0,
-      posHf2 = 0
+    let posHf1 = -1,
+      posHf2 = -1
     let index = 0
     for (const hf of hardforks) {
       if (hf['name'] === hardfork1) posHf1 = index

--- a/tests/chains.ts
+++ b/tests/chains.ts
@@ -139,6 +139,7 @@ tape('[Common]: Initialization / Chain params', function(t: tape.Test) {
       'should throw an exception on missing parameter',
     ) // eslint-disable-line no-new
 
+    st.comment('-----------------------------------------------------------------')
     st.end()
   })
 })

--- a/tests/genesisStates.ts
+++ b/tests/genesisStates.ts
@@ -17,6 +17,7 @@ tape('[genesisStates]: Genesis state access', function(t: tape.Test) {
       'Access by name (goerli)',
     )
 
+    st.comment('-----------------------------------------------------------------')
     st.end()
   })
 })

--- a/tests/hardforks.ts
+++ b/tests/hardforks.ts
@@ -70,7 +70,7 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
   t.test('activeHardforks()', function(st: tape.Test) {
     let c = new Common('ropsten')
-    st.equal(c.activeHardforks().length, 5, 'should return 5 active hardforks for Ropsten')
+    st.equal(c.activeHardforks().length, 7, 'should return 7 active hardforks for Ropsten')
     st.equal(
       c.activeHardforks()[3]['name'],
       'spuriousDragon',
@@ -90,6 +90,13 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
     c = new Common('ropsten', null, ['spuriousDragon', 'byzantium', 'constantinople'])
     st.equal(
       c.activeHardforks(null, { onlySupported: true }).length,
+      3,
+      'should return 3 active HFs when restricted to supported HFs',
+    )
+
+    c = new Common('ropsten', null, ['spuriousDragon', 'byzantium', 'dao'])
+    st.equal(
+      c.activeHardforks(null, { onlySupported: true }).length,
       2,
       'should return 2 active HFs when restricted to supported HFs',
     )
@@ -101,8 +108,8 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
     let c = new Common('ropsten')
     st.equal(
       c.activeHardfork(),
-      'byzantium',
-      'should return byzantium as latest active HF for Ropsten',
+      'petersburg',
+      'should return petersburg as latest active HF for Ropsten',
     )
     st.equal(
       c.activeHardfork(10),
@@ -171,11 +178,11 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
       'Ropsten, constantinople >= byzantium (provided) -> true',
     )
     st.equal(
-      c.hardforkGteHardfork('constantinople', 'byzantium', {
+      c.hardforkGteHardfork('dao', 'chainstart', {
         onlyActive: true,
       }),
       false,
-      'Ropsten, constantinople >= byzantium (provided), onlyActive -> fale',
+      'Ropsten, dao >= chainstart (provided), onlyActive -> false',
     )
     st.equal(
       c.hardforkGteHardfork('byzantium', 'byzantium'),
@@ -231,9 +238,9 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
       'should return false for dao (provided) on Ropsten',
     )
     st.equal(
-      c.hardforkIsActiveOnChain('constantinople'),
-      false,
-      'should return false for constantinople (provided) on Ropsten',
+      c.hardforkIsActiveOnChain('petersburg'),
+      true,
+      'should return true for petersburg (provided) on Ropsten',
     )
     st.equal(
       c.hardforkIsActiveOnChain('notexistinghardfork'),
@@ -269,6 +276,7 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
     st.equal(c.consensus('constantinople'), 'pow', 'should return pow for constantinople consensus')
     st.equal(c.finality('byzantium'), null, 'should return null for byzantium finality')
 
+    st.comment('-----------------------------------------------------------------')
     st.end()
   })
 })

--- a/tests/params.ts
+++ b/tests/params.ts
@@ -87,6 +87,11 @@ tape('[Common]: Parameter access', function(t: tape.Test) {
       200,
       'Should return updated sstore gas prices for constantinople',
     )
+    st.equal(
+      c.param('gasPrices', 'netSstoreNoopGas', 'petersburg'),
+      null,
+      'Should nullify SSTORE related values for petersburg',
+    )
 
     st.end()
   })
@@ -105,6 +110,7 @@ tape('[Common]: Parameter access', function(t: tape.Test) {
       'Should correctly translate block numbers into HF states (original value)',
     )
 
+    st.comment('-----------------------------------------------------------------')
     st.end()
   })
 })


### PR DESCRIPTION
Addresses #41.

This PR adds a new HF file for the `petersburg` HF (aka `constantinopleFix`), adds HF numbers for mainnet and ropsten and fixes a bug on HF comparison along the way (see commit messages).