### PR TITLE
Improve api for importing genesisStates, chains and hardforks in depe…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { chains as chainParams } from './chains'
 import { hardforks as hardforkChanges } from './hardforks'
+import { genesisStateById, genesisStateByName } from './genesisStates'
 
 interface hardforkOptions {
   /** optional, only allow supported HFs (default: false) */
@@ -7,6 +8,8 @@ interface hardforkOptions {
   /** optional, only active HFs (default: false) */
   onlyActive?: boolean
 }
+
+export { genesisStateById, genesisStateByName, chainParams, hardforkChanges }
 
 /**
  * Common class to access chain and hardfork parameters


### PR DESCRIPTION
This PR updates how we export the ethereumjs-common interfaces. Now all are exported for the root index file.

This will allow users to directly import/require these interfaces from 'ethereumjs-common', instead of having  to refer to a subdirectory in the module name. Without this change, users of version 1.0.0 would have to include the `dist` directory in the module path passed to require (e.g. `var genesisStateByName = require('etherumjs-common/dist/genesisStates').genesisStateByName`)

Usage example (es5):
```
var EthereumJsCommon = require('ethereumjs-common')
var Common = EthereumJsCommon.Default
var genesisStateByName = EthereumJsCommon.genesisStateByName
```

Usage example (es6):
`import Common, { chainParams } from 'ethereumjs-common'`

As it stands, the importing of these interfaces breaks in `ethereumjs-vm`. Also, none of the the dependents listed at `https://www.npmjs.com/package/ethereumjs-common` are yet using 1.0.0. And if anyone is using 1.0.0 by importing interfaces in a way that has to reference the dist directory, they can continue to do so.

Here is a PR for `ethereumjs-vm` that updates the vm to use 1.0.0 after this change is made: https://github.com/ethereumjs/ethereumjs-vm/pull/432