### PR TITLE
Org links and git hooks

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Great that you want to contribute to the `EthereumJS` [ecosystem](https://ethereumjs.readthedocs.io/en/latest/introduction.html). `EthereumJS` is managed by the Ethereum Foundation and largely driven by the wider community. Everyone is welcome to join the effort and help to improve on the libraries (see our [Code of Conduct](https://ethereumjs.readthedocs.io/en/latest/code_of_conduct.html) 🌷).
+
+We have written up some [Contribution Guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html#how-to-start) to help you getting started.
+
+These include information on how we work with **Git** and how our **general workflow** and **technical setup** looks like (stuff like language, tooling, code quality and style).
+
+Happy Coding! 👾 😀 💻

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ const mainnetGenesisState = genesisStates.genesisStateByName('mainnet')
 const mainnetGenesisState = genesisStates.genesisStateById(1) // alternative via network Id
 ```
 
+# EthereumJS
+
+See our organizational [documentation](https://ethereumjs.readthedocs.io) for an introduction to `EthereumJS` as well as information on current standards and best practices.
+
+If you want to join for work or do improvements on the libraries have a look at our [contribution guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html).
+
 # LICENSE
 
 [MIT](https://opensource.org/licenses/MIT)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "test:fix": "npm run lint:fix && npm run unitTests",
     "docs:build": "typedoc --out docs --excludePrivate --excludeExternals --mode file --readme none --theme markdown --mdEngine github src/*.ts src/genesisStates/*.ts"
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ethereumjs/ethereumjs-common.git"
@@ -51,6 +56,7 @@
     "@types/node": "^10.12.2",
     "@types/tape": "^4.2.33",
     "coveralls": "^3.0.1",
+    "husky": "^2.1.0",
     "nyc": "^11.7.1",
     "prettier": "^1.15.3",
     "tape": "^4.9.2",


### PR DESCRIPTION
Organization wide application of GitHooks https://github.com/ethereumjs/ethereumjs-account/pull/46 and organizational docs linking https://github.com/ethereumjs/ethereumjs-account/pull/49.