### PR TITLE
Draft Istanbul Support

### DIFF
--- a/src/chains/goerli.json
+++ b/src/chains/goerli.json
@@ -61,6 +61,12 @@
       "block": 0,
       "consensus": "poa",
       "finality": null
+    },
+    {
+      "name": "istanbul",
+      "block": null,
+      "consensus": "poa",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/src/chains/mainnet.json
+++ b/src/chains/mainnet.json
@@ -61,6 +61,12 @@
       "block": 7280000,
       "consensus": "pow",
       "finality": null
+    },
+    {
+      "name": "istanbul",
+      "block": null,
+      "consensus": "pow",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/src/chains/rinkeby.json
+++ b/src/chains/rinkeby.json
@@ -55,6 +55,12 @@
       "block": null,
       "consensus": "poa",
       "finality": null
+    },
+    {
+      "name": "istanbul",
+      "block": null,
+      "consensus": "poa",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/src/chains/ropsten.json
+++ b/src/chains/ropsten.json
@@ -61,6 +61,12 @@
       "block": 4939394,
       "consensus": "pow",
       "finality": null
+    },
+    {
+      "name": "istanbul",
+      "block": null,
+      "consensus": "pow",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/src/hardforks/index.ts
+++ b/src/hardforks/index.ts
@@ -7,4 +7,5 @@ export const hardforks = [
   ['byzantium', require('./byzantium.json')],
   ['constantinople', require('./constantinople.json')],
   ['petersburg', require('./petersburg.json')],
+  ['istanbul', require('./istanbul.json')],
 ]

--- a/src/hardforks/istanbul.json
+++ b/src/hardforks/istanbul.json
@@ -1,0 +1,14 @@
+{
+  "name": "istanbul",
+  "comment": "HF targeted for October 2019 following the Constantinople/Petersburg HF",
+  "eip": {
+    "url": "https://eips.ethereum.org/EIPS/eip-1679",
+    "status": "Draft"
+  },
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {},
+  "casper": {},
+  "sharding": {}
+}

--- a/tests/hardforks.ts
+++ b/tests/hardforks.ts
@@ -11,6 +11,8 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
       'spuriousDragon',
       'byzantium',
       'constantinople',
+      'petersburg',
+      'istanbul',
     ]
     let c
 


### PR DESCRIPTION
Would like to release this as ``v1.2.0`` (could technically be also ``v1.1.x`` but then it becomes more transparent where Istanbul integration is prepared in other libraries) and then do subsequent parameter additions as ``v1.2.x`` releases.

This is mainly that we have a clear ``Istanbul`` HF switch for the VM and can start implementations around https://github.com/ethereumjs/ethereumjs-vm/issues/501 with https://github.com/ethereumjs/ethereumjs-vm/issues/519 eventually as a first implementation target.