### PR TITLE
New release v1.2.1 (added draft EIP-1108 alt_bn128 gas costs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2019-06-03
+
+- Added `Istanbul` HF candidate [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108)
+  (`DRAFT`) updated `alt_bn128` precompile gas costs (see `hardforks/istanbul.json`)
+
+[1.2.1]: https://github.com/ethereumjs/ethereumjs-common/compare/v1.2.0...v1.2.1
+
 ## [1.2.0] - 2019-05-27
 
 **DRAFT Istanbul Hardfork Support**

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ to ease `blockNumber` based access to parameters.
 
 # Hardfork Params
 
+## Active Hardforks
+
 There are currently parameter changes by the following past and future hardfork by the
 library supported:
 
@@ -73,7 +75,19 @@ library supported:
 - `byzantium`
 - `constantinople`
 - `petersburg` (aka `constantinopleFix`, apply together with `constantinople`)
-- `istanbul` (`DRAFT`)
+
+## Future Hardforks
+
+Scope and technical details on the `Istanbul` HF are currently forming out
+within [EIP-1679](https://eips.ethereum.org/EIPS/eip-1679) respectively the
+associated EIP pages.
+
+Supported EIPs in the library:
+
+- [EIP-1108](https://eips.ethereum.org/EIPS/eip-1108) `alt_bn128` precompile
+  gas cost reductions (HF candidate, `DRAFT` status)
+
+## Parameter Access
 
 For hardfork-specific parameter access with the `param()` and `paramByBlock()` functions
 you can use the following `topics`:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereumjs-common",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Resources common to all Ethereum implementations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/hardforks/istanbul.json
+++ b/src/hardforks/istanbul.json
@@ -6,7 +6,24 @@
     "status": "Draft"
   },
   "gasConfig": {},
-  "gasPrices": {},
+  "gasPrices": {
+    "ecAdd": {
+      "v": 150,
+      "d": "Gas costs for curve addition precompile"
+    },
+    "ecMul": {
+      "v": 6000,
+      "d": "Gas costs for curve multiplication precompile"
+    },
+    "ecPairing": {
+      "v": 45000,
+      "d": "Base gas costs for curve pairing precompile"
+    },
+    "ecPairingWord": {
+      "v": 34000,
+      "d": "Gas costs regarding curve pairing precompile input length"
+    }
+  },
   "vm": {},
   "pow": {},
   "casper": {},


### PR DESCRIPTION
After reading [this tweet](https://twitter.com/nanexcool/status/1133808384204050433) I thought it would actually be fun to directly start integrating a first EIP in the `v4` release of the VM.

There is all this talk on the [AllCoreDevs](https://gitter.im/ethereum/AllCoreDevs) Gitter channel on reference implementations of EIPs, since this time there seems to be the need of some "Champion", so 1-2 implementations of EIPs until they get accepted, as far as I understand also for the more simple onces (since it wouldn't make sense to draw some line here (where to draw?).).

`EIP-1108` is a good fit for a start, since while really simple it has large benefits and would help Aztec privacy protocol a lot, on the same time it's really easy for us here to integrate.

I think this also has very much some real world use, since people then have some first tool to run there contracts against which can be used to develop some feeling for the changing gas costs and investigate further respectively prepare.

Beside it would draw some attention to the VM 😋 (I think it would really deserve some more). Our VM is actually generally very much suited for experimentation like this, since JavaScript is pretty accessible for many people. Maybe we can establish a bit in the whole process as some research VM and eventually also get some implementations for free along the process. 😄 😛 Especially for people coming from the outside with not too deep VM knowledge yet it's then pretty valuable to have a first EIP implementation done which one can reference and go along on own implementations.

I've also directly integrated the release bump and preparation, since I think these one-by-one additions of EIP parameters for `Istanbul` on this library will be pretty deterministic in release planning and should ease the process a bit.