### PR TITLE
Adding Kovan forks

### DIFF
--- a/src/chains/kovan.json
+++ b/src/chains/kovan.json
@@ -58,7 +58,7 @@
     },
     {
       "name": "petersburg",
-      "block": 7280000,
+      "block": 10255201,
       "consensus": "poa",
       "finality": null
     },

--- a/src/chains/kovan.json
+++ b/src/chains/kovan.json
@@ -13,7 +13,62 @@
     "extraData": "0x",
     "stateRoot": "0x2480155b48a1cea17d67dbfdfaafe821c1d19cdd478c5358e8ec56dec24502b2"
   },
-  "hardforks": [],
+  "hardforks": [
+    {
+      "name": "chainstart",
+      "block": 0,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "homestead",
+      "block": 0,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "dao",
+      "block": 0,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "tangerineWhistle",
+      "block": 0,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "spuriousDragon",
+      "block": 0,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "byzantium",
+      "block": 5067000,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "constantinople",
+      "block": 9200000,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "petersburg",
+      "block": 7280000,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "istanbul",
+      "block": 14111141,
+      "consensus": "poa",
+      "finality": null
+    }
+  ],
   "bootstrapNodes": [
     {
       "ip": "40.71.221.215",


### PR DESCRIPTION
The table below shows evidence of the fork numbers.

| block | date | name |
| -----|-----|----------------|
| [`0`](https://kovan.etherscan.io/block/0) | mar-2017 | Kovan genesis |
| [`5,067,000`](https://kovan.etherscan.io/block/5067000) | dec-2017 | [Byzantium](https://github.com/paritytech/parity-ethereum/releases/tag/v1.7.10)
| [`9,200,000`](https://kovan.etherscan.io/block/9200000) |  oct-2018 | [Constantinople](https://eips.ethereum.org/EIPS/eip-1013) [[2](https://www.parity.io/parity-ethereum-2-1-2-beta-constantinople-coming-to-kovan-and-ropsten/)]
| [`10,255,201`](https://kovan.etherscan.io/block/10255201) | feb-2019 | [Petersburg](https://eips.ethereum.org/EIPS/eip-1716)
| [`14,111,141`](https://kovan.etherscan.io/block/14111141) | oct-2019 | [Istanbul](https://eips.ethereum.org/EIPS/eip-1679)


Closes #57.