### PR TITLE
Adding Petersburg and Constantinople fork blocks to Rinkeby

### DIFF
--- a/src/chains/rinkeby.json
+++ b/src/chains/rinkeby.json
@@ -58,7 +58,7 @@
     },
     {
       "name": "petersburg",
-      "block": 9999999,
+      "block": 4321234,
       "consensus": "poa",
       "finality": null
     },

--- a/src/chains/rinkeby.json
+++ b/src/chains/rinkeby.json
@@ -52,7 +52,13 @@
     },
     {
       "name": "constantinople",
-      "block": null,
+      "block": 3660663,
+      "consensus": "poa",
+      "finality": null
+    },
+    {
+      "name": "petersburg",
+      "block": 9999999,
       "consensus": "poa",
       "finality": null
     },


### PR DESCRIPTION
The table below shows evidence of the fork numbers.

| block | date | name |
| -----|-----|----------------|
| [`3,660,663`](https://rinkeby.etherscan.io/block/3660663) |  jan-2019 | [Constantinople](https://eips.ethereum.org/EIPS/eip-1013)
| [`4,321,234`](https://rinkeby.etherscan.io/block/4321234) | may-2019 | [Petersburg](https://eips.ethereum.org/EIPS/eip-1716)

Note 1: [EIP 1716](https://eips.ethereum.org/EIPS/eip-1716) mistakenly says Petersburg would activate in block 9,999,999 (in two years from now). I sent a PR aiming to correct it to the block number `4,321,234`, introduced by [Geth 1.8.24](https://eips.ethereum.org/EIPS/eip-1716).

Note 2: Istanbul block number is taken care by PR #68.

