### PR TITLE
Adds definition for HF Muir Glacier

### DIFF
--- a/src/chains/mainnet.json
+++ b/src/chains/mainnet.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "muirGlacier",
-      "block": 9169000,
+      "block": 9200000,
       "consensus": "pow",
       "finality": null
     }

--- a/src/chains/mainnet.json
+++ b/src/chains/mainnet.json
@@ -69,7 +69,7 @@
       "finality": null
     },
     {
-      "name": "eip2384",
+      "name": "mountainGlacier",
       "block": 9169000,
       "consensus": "pow",
       "finality": null

--- a/src/chains/mainnet.json
+++ b/src/chains/mainnet.json
@@ -69,7 +69,7 @@
       "finality": null
     },
     {
-      "name": "mountainGlacier",
+      "name": "muirGlacier",
       "block": 9169000,
       "consensus": "pow",
       "finality": null

--- a/src/chains/mainnet.json
+++ b/src/chains/mainnet.json
@@ -67,6 +67,12 @@
       "block": 9069000,
       "consensus": "pow",
       "finality": null
+    },
+    {
+      "name": "eip2384",
+      "block": 9169000,
+      "consensus": "pow",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/src/chains/ropsten.json
+++ b/src/chains/ropsten.json
@@ -69,7 +69,7 @@
       "finality": null
     },
     {
-      "name": "eip2384",
+      "name": "mountainGlacier",
       "block": 6585846,
       "consensus": "pow",
       "finality": null

--- a/src/chains/ropsten.json
+++ b/src/chains/ropsten.json
@@ -67,6 +67,12 @@
       "block": 6485846,
       "consensus": "pow",
       "finality": null
+    },
+    {
+      "name": "eip2384",
+      "block": 6585846,
+      "consensus": "pow",
+      "finality": null
     }
   ],
   "bootstrapNodes": [

--- a/src/chains/ropsten.json
+++ b/src/chains/ropsten.json
@@ -69,7 +69,7 @@
       "finality": null
     },
     {
-      "name": "mountainGlacier",
+      "name": "muirGlacier",
       "block": 6585846,
       "consensus": "pow",
       "finality": null

--- a/src/chains/ropsten.json
+++ b/src/chains/ropsten.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "muirGlacier",
-      "block": 6585846,
+      "block": 7117117,
       "consensus": "pow",
       "finality": null
     }

--- a/src/hardforks/index.ts
+++ b/src/hardforks/index.ts
@@ -8,5 +8,5 @@ export const hardforks = [
   ['constantinople', require('./constantinople.json')],
   ['petersburg', require('./petersburg.json')],
   ['istanbul', require('./istanbul.json')],
-  ['eip2384', require('./eip2384.json')],
+  ['mountainGlacier', require('./mountainGlacier.json')],
 ]

--- a/src/hardforks/index.ts
+++ b/src/hardforks/index.ts
@@ -8,4 +8,5 @@ export const hardforks = [
   ['constantinople', require('./constantinople.json')],
   ['petersburg', require('./petersburg.json')],
   ['istanbul', require('./istanbul.json')],
+  ['eip2384', require('./eip2384.json')],
 ]

--- a/src/hardforks/index.ts
+++ b/src/hardforks/index.ts
@@ -8,5 +8,5 @@ export const hardforks = [
   ['constantinople', require('./constantinople.json')],
   ['petersburg', require('./petersburg.json')],
   ['istanbul', require('./istanbul.json')],
-  ['mountainGlacier', require('./mountainGlacier.json')],
+  ['muirGlacier', require('./muirGlacier.json')],
 ]

--- a/src/hardforks/mountainGlacier.json
+++ b/src/hardforks/mountainGlacier.json
@@ -1,0 +1,14 @@
+{
+  "name": "mountainGlacier",
+  "comment": "HF to delay the difficulty bomb",
+  "eip": {
+    "url": "https://github.com/ethereum/EIPs/pull/2384",
+    "status": "PR"
+  },
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {},
+  "casper": {},
+  "sharding": {}
+}

--- a/src/hardforks/muirGlacier.json
+++ b/src/hardforks/muirGlacier.json
@@ -3,7 +3,7 @@
   "comment": "HF to delay the difficulty bomb",
   "eip": {
     "url": "https://eips.ethereum.org/EIPS/eip-2384",
-    "status": "PR"
+    "status": "Last Call"
   },
   "gasConfig": {},
   "gasPrices": {},

--- a/src/hardforks/muirGlacier.json
+++ b/src/hardforks/muirGlacier.json
@@ -2,7 +2,7 @@
   "name": "muirGlacier",
   "comment": "HF to delay the difficulty bomb",
   "eip": {
-    "url": "https://github.com/ethereum/EIPs/pull/2384",
+    "url": "https://eips.ethereum.org/EIPS/eip-2384",
     "status": "PR"
   },
   "gasConfig": {},

--- a/src/hardforks/muirGlacier.json
+++ b/src/hardforks/muirGlacier.json
@@ -1,5 +1,5 @@
 {
-  "name": "mountainGlacier",
+  "name": "muirGlacier",
   "comment": "HF to delay the difficulty bomb",
   "eip": {
     "url": "https://github.com/ethereum/EIPs/pull/2384",

--- a/tests/chains.ts
+++ b/tests/chains.ts
@@ -26,7 +26,7 @@ tape('[Common]: Initialization / Chain params', function(t: tape.Test) {
   t.test('Should initialize with supportedHardforks provided', function(st: tape.Test) {
     const c = new Common('mainnet', 'byzantium', ['byzantium', 'constantinople'])
     st.equal(c._isSupportedHardfork('byzantium'), true, 'should return true for supported HF')
-    let msg = 'should return false for unsupported HF'
+    const msg = 'should return false for unsupported HF'
     st.equal(c._isSupportedHardfork('spuriousDragon'), false, msg)
 
     st.end()
@@ -56,7 +56,7 @@ tape('[Common]: Initialization / Chain params', function(t: tape.Test) {
 
   t.test('Should provide correct access to chain parameters', function(st: tape.Test) {
     const c = new Common('mainnet')
-    let hash = '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'
+    const hash = '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'
     st.equal(c.genesis().hash, hash, 'should return correct genesis hash')
     st.equal(c.hardforks()[3]['block'], 2463000, 'should return correct hardfork data')
     st.equal(c.bootstrapNodes()[0].port, 30303, 'should return a bootstrap node array')

--- a/tests/hardforks.ts
+++ b/tests/hardforks.ts
@@ -60,8 +60,8 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
   t.test('activeHardforks()', function(st: tape.Test) {
     let c = new Common('ropsten')
-    let msg = 'should return 8 active hardforks for Ropsten'
-    st.equal(c.activeHardforks().length, 8, msg)
+    let msg = 'should return 9 active hardforks for Ropsten'
+    st.equal(c.activeHardforks().length, 9, msg)
 
     msg = 'should return the correct HF data for Ropsten'
     st.equal(c.activeHardforks()[3]['name'], 'spuriousDragon', msg)
@@ -89,8 +89,8 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
   t.test('activeHardfork()', function(st: tape.Test) {
     let c = new Common('ropsten')
-    let msg = 'should return istanbul as latest active HF for Ropsten'
-    st.equal(c.activeHardfork(), 'istanbul', msg)
+    let msg = 'should return eip2384 as latest active HF for Ropsten'
+    st.equal(c.activeHardfork(), 'eip2384', msg)
 
     msg = 'should return spuriousDragon as latest active HF for Ropsten for block 10'
     st.equal(c.activeHardfork(10), 'spuriousDragon', msg)
@@ -164,6 +164,14 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
     msg = 'Ropsten, byzantium (set) >= constantinople -> false'
     st.equal(c.hardforkGteHardfork(null, 'constantinople'), false, msg)
+
+    st.end()
+  })
+
+  t.test('hardforkGteHardfork() ropsten', function(st: tape.Test) {
+    const c = new Common('ropsten')
+    const msg = 'ropsten, spuriousDragon >= eip2384 (provided) -> false'
+    st.equal(c.hardforkGteHardfork('spuriousDragon', 'eip2384'), false, msg)
 
     st.end()
   })

--- a/tests/hardforks.ts
+++ b/tests/hardforks.ts
@@ -107,6 +107,10 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
     msg = 'should return spuriousDragon as latest active HF for Ropsten with limited supported HFs'
     st.equal(c.activeHardfork(null, { onlySupported: true }), 'spuriousDragon', msg)
 
+    c = new Common('rinkeby')
+    msg = 'should return Istanbul as latest active HF for Rinkeby'
+    st.equal(c.activeHardfork(), 'istanbul', msg)
+
     st.end()
   })
 

--- a/tests/hardforks.ts
+++ b/tests/hardforks.ts
@@ -89,8 +89,8 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
   t.test('activeHardfork()', function(st: tape.Test) {
     let c = new Common('ropsten')
-    let msg = 'should return mountainGlacier as latest active HF for Ropsten'
-    st.equal(c.activeHardfork(), 'mountainGlacier', msg)
+    let msg = 'should return muirGlacier as latest active HF for Ropsten'
+    st.equal(c.activeHardfork(), 'muirGlacier', msg)
 
     msg = 'should return spuriousDragon as latest active HF for Ropsten for block 10'
     st.equal(c.activeHardfork(10), 'spuriousDragon', msg)
@@ -170,8 +170,8 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
   t.test('hardforkGteHardfork() ropsten', function(st: tape.Test) {
     const c = new Common('ropsten')
-    const msg = 'ropsten, spuriousDragon >= mountainGlacier (provided) -> false'
-    st.equal(c.hardforkGteHardfork('spuriousDragon', 'mountainGlacier'), false, msg)
+    const msg = 'ropsten, spuriousDragon >= muirGlacier (provided) -> false'
+    st.equal(c.hardforkGteHardfork('spuriousDragon', 'muirGlacier'), false, msg)
 
     st.end()
   })

--- a/tests/hardforks.ts
+++ b/tests/hardforks.ts
@@ -84,6 +84,14 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
     msg = 'should return 10 active HFs for mainnet'
     st.equal(c.activeHardforks().length, 10, msg)
 
+    c = new Common('rinkeby')
+    msg = 'should return 8 active HFs for rinkeby'
+    st.equal(c.activeHardforks().length, 8, msg)
+
+    c = new Common('goerli')
+    msg = 'should return 9 active HFs for goerli'
+    st.equal(c.activeHardforks().length, 9, msg)
+
     st.end()
   })
 

--- a/tests/hardforks.ts
+++ b/tests/hardforks.ts
@@ -89,8 +89,8 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
   t.test('activeHardfork()', function(st: tape.Test) {
     let c = new Common('ropsten')
-    let msg = 'should return eip2384 as latest active HF for Ropsten'
-    st.equal(c.activeHardfork(), 'eip2384', msg)
+    let msg = 'should return mountainGlacier as latest active HF for Ropsten'
+    st.equal(c.activeHardfork(), 'mountainGlacier', msg)
 
     msg = 'should return spuriousDragon as latest active HF for Ropsten for block 10'
     st.equal(c.activeHardfork(10), 'spuriousDragon', msg)
@@ -170,8 +170,8 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
 
   t.test('hardforkGteHardfork() ropsten', function(st: tape.Test) {
     const c = new Common('ropsten')
-    const msg = 'ropsten, spuriousDragon >= eip2384 (provided) -> false'
-    st.equal(c.hardforkGteHardfork('spuriousDragon', 'eip2384'), false, msg)
+    const msg = 'ropsten, spuriousDragon >= mountainGlacier (provided) -> false'
+    st.equal(c.hardforkGteHardfork('spuriousDragon', 'mountainGlacier'), false, msg)
 
     st.end()
   })

--- a/tests/hardforks.ts
+++ b/tests/hardforks.ts
@@ -80,6 +80,10 @@ tape('[Common]: Hardfork logic', function(t: tape.Test) {
     msg = 'should return 2 active HFs when restricted to supported HFs'
     st.equal(c.activeHardforks(null, { onlySupported: true }).length, 2, msg)
 
+    c = new Common('mainnet')
+    msg = 'should return 10 active HFs for mainnet'
+    st.equal(c.activeHardforks().length, 10, msg)
+
     st.end()
   })
 

--- a/tests/params.ts
+++ b/tests/params.ts
@@ -55,7 +55,7 @@ tape('[Common]: Parameter access', function(t: tape.Test) {
 
   t.test('Parameter updates', function(st: tape.Test) {
     const c = new Common('mainnet')
-    let f = function() {
+    const f = function() {
       c.param('gasPrices', 'ecAdd', 'spuriousDragon')
     }
     let msg = 'Should throw for a value set on a later HF'


### PR DESCRIPTION
Block numbers are still temporary.

It is only relevant for pow chains, therefore it is only present in Ropsten and Mainnet. Please let me know if should I include it elsewhere.