### PR TITLE
Changes EIP links to preferred citation format

### DIFF
--- a/src/hardforks/petersburg.json
+++ b/src/hardforks/petersburg.json
@@ -2,7 +2,7 @@
   "name": "petersburg",
   "comment": "Aka constantinopleFix, removes EIP-1283, activate together with or after constantinople",
   "eip": {
-    "url": "https://github.com/ethereum/EIPs/pull/1716",
+    "url": "https://eips.ethereum.org/EIPS/eip-1716",
     "status": "Draft"
   },
   "gasConfig": {},


### PR DESCRIPTION
While updating the links across the 6 repos for the migration, I bumped into these different formats for EIP links. As they does not impact the migration, I decided to update them now.

> **Preferred Citation Format [1]**
> The canonical URL for a EIP that has achieved draft status at any point is at https://eips.ethereum.org/. For example, the canonical URL for EIP-1 is https://eips.ethereum.org/EIPS/eip-1.

[Reference](https://github.com/ethereum/EIPs/blob/af677b348da866d41a58d8948a89d0b00d410e2b/README.md#preferred-citation-format).